### PR TITLE
Add Affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Please open a PR to be added.
 - [Apollo Agriculture](https://apolloagriculture.com/) | Nairobi, Kenya/Remote | Takehome project or Worksample (or whiteboard)
 - [Abstract](https://angel.co/abstract/jobs) | San Francisco, CA
 - [Adthena](http://adthena.com) | London, UK | Takehome  project and discussion on-site
+- [Affinity](https://affinity.recruiterbox.com/#content) | San Francisco, CA | Implementation of a children's game, then take-home project OR real-world design questions
 - [Algolia](https://www.algolia.com/careers) | Paris, France / San Francisco, CA | Takehome project & Onsite discussions and presentation
 - [Arachnys](https://angel.co/arachnys/jobs/220465-software-engineer) | London, UK | Take home test, real world pair programming
 - [Articulate](https://articulate.com/company/careers) | 100% remote | Take-home project & pair program on a problem similar to daily work


### PR DESCRIPTION
I'm proposing the addition of [Affinity](https://affinity.co/) (disclaimer: I work here). We've just redesigned our interview process to remove questions that don't mimic real coding problems you see day to day. We ask candidates to implement a children's game (ie. Connect 4, etc), then give a choice between a take-home project or a set of interview questions inspired from tasks we've had to accomplish here at our job. Hopefully they fit the bill of non-whiteboard questions!