### PR TITLE
Food52

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Please open a PR to be added.
 - [Etix Everywhere](https://www.etixeverywhere.com/en/job-offers/) | Luxembourg
 - [Fitbot](https://thefitbot.com/careers.html) | Boulder, CO | Pairing & writing code with the founders for a few hours
 - [Fog Creek](https://www.fogcreek.com/careers) | NYC, remote
+- [Food52](https://food52.com/jobs) | NYC, remote | Take-home project, discussion on-site or remote, interviews with both technical and non-technical staff
 - [Formidable Labs](https://www.formidable.com/careers) | Seattle, London, Remote | Take-home project, remote pair programming, discussion on-site or remote
 - [Fooji](https://fooji.com) | Lexington, KY, remote | Take-home project
 - [Founders](https://founders.as/joinus) | Copenhagen, Denmark | Take Home project + Interviews


### PR DESCRIPTION
Company Bio:

> We're Food52, and we've created a groundbreaking and award-winning cooking and home site. We support, connect, and celebrate home cooks, and give them everything they need in one place.
We have a top editorial, business, and engineering team that’s focused on using technology to find new and better ways to connect people around their interests. We offer superb, highly curated information about food, cooking, design, culture, and travel and, through our shop, we sell the smartly-designed kitchen and home goods to match. Our site attracts the most talented home cooks and contributors in the country; we also feature well-known professionals like Mario Batali, Jacques Pépin, Alton Brown, Gwyneth Paltrow, and Danny Meyer. And we have partnerships with brands like KitchenAid and Random House

> Food52 has been named the best food website by the James Beard Foundation and IACP, and has been featured in the New York Times, Wall Street Journal, NPR, The Dish, Martha Stewart, Bon Appétit, and many more.

> We're located in Chelsea, in New York City.

> Please note: Food52 hopes to recruit and advance qualified minorities, women, LGBTQ, persons with disabilities, and veterans—we welcome and encourage all applicants. Our goal is for our team and culture to reflect the diversity of the global community of home cooks.