### PR TITLE
Adding Hill Holliday

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See https://news.ycombinator.com/item?id=13874026
 - [Heap](https://heapanalytics.com/jobs) | San Francisco/Remote | Practical, self-contained onsite project
 - [HelloFresh](https://www.hellofresh.com/jobs/) | Berlin, Germany | Take-home project, discussion via Skype or on-site
 - [Heptio](https://www.heptio.com/jobs/) | Seattle/Remote | Take-home project, discussion on-site
+- [Hill Holliday](http://www.hhcc.com/careers/) | Boston, MA | Take-home project on GitHub, in-person interview / culture fit interview
 - [HoxHunt](https://jobs.hoxhunt.com/) | Helsinki, Finland | Take-home project, pair programming on-site
 - [ImmobilienScout24](https://boards.greenhouse.io/scout24) | Berlin, Germany | Take-home project, discussion on-site
 - [Impraise](http://jobs.impraise.com) | Amsterdam, The Netherlands | Take home test, real world pair programming


### PR DESCRIPTION
Adding our company, Hill Holliday, an advertising agency in Boston, MA, to this fine list of companies that don't believe in whiteboarding 😎.