### PR TITLE
Added entry for Novus partners (www.novus.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ See https://news.ycombinator.com/item?id=13874026
 - [Nomoko,camera](https://www.nomoko.world/jobs) | Zurich, Switzerland | Three interrogations
 - [NoRedInk](https://www.noredink.com/jobs) | San Francisco, CA | Take-home exercise & pair programming session
 - [NoviCap](https://novicap.com/en/careers.html) | Barcelona, Spain | Takehome exercise & discussion on-site
+- [Novus Partners](https://www.novus.com/jobs/) | New York, NY | Take-home exercise ([example](https://github.com/noahlz/tactical-engineer-test)) & on-site exercises (choice of laptop or whiteboard)
 - [Nozbe](https://nozbe.com/jobs/) | Everywhere (Remote) | Take-home exercise & interview with the team
 - [npm, Inc](https://npmjs.com/jobs) | Oakland, CA/remote | No technical challenges. Just interview conversations.
 - [numberly](https://www.numberly.com) | Paris, France | Series of interviews, that go over technical background, past experiences and cultural knowledge

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ See https://news.ycombinator.com/item?id=13874026
 - [Nomoko,camera](https://www.nomoko.world/jobs) | Zurich, Switzerland | Three interrogations
 - [NoRedInk](https://www.noredink.com/jobs) | San Francisco, CA | Take-home exercise & pair programming session
 - [NoviCap](https://novicap.com/en/careers.html) | Barcelona, Spain | Takehome exercise & discussion on-site
-- [Novus Partners](https://www.novus.com/jobs/) | New York, NY | Take-home exercise ([example](https://github.com/noahlz/tactical-engineer-test)) & on-site exercises (choice of laptop or whiteboard)
+- [Novus Partners](https://www.novus.com/jobs/) | New York, NY | Take-home exercise & on-site exercises (choice of laptop or whiteboard)
 - [Nozbe](https://nozbe.com/jobs/) | Everywhere (Remote) | Take-home exercise & interview with the team
 - [npm, Inc](https://npmjs.com/jobs) | Oakland, CA/remote | No technical challenges. Just interview conversations.
 - [numberly](https://www.numberly.com) | Paris, France | Series of interviews, that go over technical background, past experiences and cultural knowledge


### PR DESCRIPTION
With link to example take-home test we used in the past:

https://github.com/noahlz/tactical-engineer-test

Blog post / manifesto:

https://tech.novus.com/make-them-prove-they-can-code-and-actually-do-the-job/

