### PR TITLE
Update Link for Yhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ See [HackerNews](https://news.ycombinator.com/item?id=13874026).
 - [500friends](http://500friends.com/who-we-are/careers) | San Francisco, CA; Remote | Take home challenge followed by onsite expansion of the submission and high level discussions (design exercise or overview of past projects)
 - [500Tech](https://500Tech.com) | Tel Aviv, Israel | Pair programming on a laptop in working env
 - [8th Light](https://8thlight.com) | Chicago, IL; London, UK; Los Angeles, CA; New York, NY | Take home code challenge, discussion, pair programming session
-- [Yhat](https://www.yhat.com/company) | Brooklyn, NY | Demo something cool you built and walk us thru the code + design decisions
+- [Yhat](https://www.yhat.com/jobs) | Brooklyn, NY | Demo something cool you built and walk us thru the code + design decisions
 - [YLD](https://yld.breezy.hr) | London, UK | Take home-code challenge, pair-programming session and discussion about past experience
 - [Yodas](https://yodas.com) | Binyamina, Israel | Coding tasks over github repository
 - [Yoyo Wallet](http://yoyowallet.com) | London, UK | Take home code challenge, discussion of the code challenge, and general, high level questions


### PR DESCRIPTION
I noticed that the link for Yhat redirected to the company page and not the actual jobs page so I just updated the link.

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have followed the [format](../CONTRIBUTING.md#format) prescribed in the contributing guidelines