### PR TITLE
fix links in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,9 @@ Please also:
 
 ## Add/Update/Remove <CompanyName>
 
-- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md)
-- [ ] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
-- [ ] I have followed the [format](../CONTRIBUTING.md#format) prescribed in the contributing guidelines
+- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
+- [ ] I agree to the [Code of Conduct](../blob/master/CODE_OF_CONDUCT.md)
+- [ ] I have followed the [format](../blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
 - [ ] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,9 @@ Please also:
 
 ## Add/Update/Remove <CompanyName>
 
-- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
-- [ ] I agree to the [Code of Conduct](../blob/master/CODE_OF_CONDUCT.md)
-- [ ] I have followed the [format](../blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
+- [ ] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
+- [ ] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
+- [ ] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
 - [ ] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary
 
 <!--


### PR DESCRIPTION
## fix internal doc links in PRs

The links in PRs such as #517 don't go to the relevant docs, they just say "Not Found". I don't know how to link from a PR to "a given file in in the current branch" so this PR updates them to point to the `master` branch.

Unfortunately this means that the links are broken in the file view https://github.com/poteto/hiring-without-whiteboards/blob/master/.github/PULL_REQUEST_TEMPLATE.md but I don't think it's possible to get both given current Github limitations?
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have followed the [format](../CONTRIBUTING.md#format) prescribed in the contributing guidelines
<!--
Please give additional context about the interview process if necessary.
-->
