### PR TITLE
Remove DataCentred as they no longer exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ Additions to this document that are properly formatted will automatically be pus
 ## D - F
 - [Dark Sky](https://darksky.net/jobs) | Cambridge, MA | Phone interviews and a very short, real paid project
 - [Data Theorem](http://www.datatheorem.com) | Palo Alto, CA; Paris, Fr; Bangladesh, India | Phone interview, then a take home project and finally in-person interview.
-- [DataCentred](http://www.datacentred.co.uk/careers) | Manchester, UK & Remote | Pair programming with team, project to work on at home
 - [Datalogue](https://datalogue.github.io/recruiting) | Montreal, Canada | We Ask candidates to contribute meaningfully to an Open source project that reflects the stack they will be working with and send us a link to the PR.
 - [Datascope](https://datascope.co/careers) | Chicago, IL | Take home exploratory data project with public data, discussion about the project via video chat, and in-person office visit.
 - [Datlinq](http://www.datlinq.com/en/vacancies) | Rotterdam, Netherlands | Take-home project based on actual work on data done by the team and in-person or Skype interviews


### PR DESCRIPTION
## Remove DataCentred

This PR removes DataCentred as they are sadly no longer trading:

https://www.datacenterdynamics.com/news/datacentred-is-shutting-down-after-losing-hmrc-as-a-customer/