### PR TITLE
Update CRITERIA.md - NO UNPAID PROJECTS

### DIFF
--- a/CRITERIA.md
+++ b/CRITERIA.md
@@ -4,5 +4,6 @@ In order to be accepted into this list, the company's interview process **must n
 
 - Ask CS trivia/brainteasers/riddles/puzzles/etc that DO NOT relate to the job the candidate is applying for
 - Use live-coding sites like HackerRank or LeetCode
+- Use unpaid take home projects.
 
 The only exceptions to the above is where CS knowledge is a **requirement** of the role. For example, if you are being hired to write a package manager, you probably need to understand DAGs.


### PR DESCRIPTION
Unpaid take home projects are wrong. We deserve a wage for labor that we provide, and the promise of a job someday isn't good enough, given the behavior of most hiring companies.

Unpaid take home projects make it hard for anyone who is already employed, has children, cares for a sick or elderly family member, etc. to be successful. Even when such a project is completed, the hiring party often ghosts candidates or doesn't provide feedback.  All of this benefits the company and not the potential employee.

Maybe some reasonable parameters around unpaid projects could be established (1hr? VM already set up w/ dev environment? Timeline for notification after the project is submitted? Feedback of some kind?)

But lacking that, we should disallow them altogether until there's some sanity in the process.

At the very least, we could add a label to all the companies in the list that require unpaid take home projects.

<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Add/Update/Remove <CompanyName>

- [x ] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x ] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x ] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
