### PR TITLE
Remove TransferWise due to HackerRank and trivia

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,6 @@ Additions to this document that are properly formatted will automatically be pus
 - [TrademarkVision](https://trademark.vision) | Brisbane, Australia | On site interview and quick take-home excercise
 - [TrainHeroic](http://trainheroic.com/careers/) | Boulder, CO; Denver, CO | Phone screen, take home project, remote and on-site interviews for technical and cultural fit
 - [TrainingPeaks](http://www.trainingpeaks.com/careers.html) | Boulder, CO; Denver, CO | Phone screen, take home project, remote and on-site interviews for technical and cultural fit
-- [TransferWise](https://transferwise.com/jobs/) | London, UK; New York, NY; Tallin, Estonia; Tokyo, Japan | Phone screen, take home project and interviews (remote or on-site, you can choose) for technical and cultural fit.
 - [TripStack](http://www.tripstack.com/company/careers/) | Toronto, Canada | Take-home assignment, followed up by a face to face code walk through
 - [Trivago](https://www.trivago.com) | Düsseldorf, Germany | Case Study, Skype Interview, On site Interview with some code review exercises
 - [Trōv](https://boards.greenhouse.io/trov) | Remote | Take-home project with followup interview from actual prospective teammates


### PR DESCRIPTION
<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Remove TransferWise

- [x] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x] I have read the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [x] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->

TransferWise are now "experimenting" with a whiteboard interview. The actual (timed) exercise requires use of the awful HackerRank interface, and includes several trivia questions where no Google/StackOverflow is allowed. So much *nope*.

As per TransferWise recruiter email:

> **Tech test** - a bit unusual to start with this but we are currently experimenting this scheme and we thank you in advance for your support with this :) This will be a HackerRank online test which I will send to you after this e-mail (pls check your spam section also to make sure it does not land there). This should take you max. 90 min. and if results are good we'll move ahead. Normally we don't have a fix deadline for completing it but will be great if you can do within 3 days or latest within 1 week which should give you enough time I think. Also, pls focus on the coding questions (which will normally come at the end), as those are weighting the most in the final score :) Please also avoid using Google/finding a solution on Stack Overflow
