### PR TITLE
Removed Telus, they heavily use hackerrank

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,6 @@ Also check out [No Whiteboards](https://nowhiteboards.io) to search for jobs at 
 - [Tara AI](https://tara.ai/about/careers) | San Jose, CA | On-site interview with a deep dive into appropriate technology and our problem space. The same sort of problem solving you would do with peers after a standup
 - [Tattoodo](https://www.tattoodo.com) | Copenhagen, Denmark | Takehome exercise
 - [Taxdoo](https://www.taxdoo.com/#/jobs/) | Hamburg, Germany | On-site interview, little takehome exercise, followup review/interview
-- [Telus Digital](https://labs.telus.com) | Toronto, Canada; Vancouver, Canada | Discuss knowledge and interest, explore previous work, pair with developers when possible, alternatively take home project.
 - [Ten Thousand Coffees](https://tenthousandcoffees.com) | Toronto, Canada | Take home project, then explain how you solved the project
 - [Tes](https://engineering.tes.com/recruitment/) | Remote; London, UK | Remote pair programming session on React/Node kata with small takehome exercise as prep. Remote interview with senior engineers about previous experience, technical knowledge and interests.
 - [Tesco PLC](https://www.tesco.com) | London, United Kingdom | Pair programming and casual hypothetical system design discussion


### PR DESCRIPTION
<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Remove Telus

- [x] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [x] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
Telus does not belong here at all. They always send 90 minute Hackerank/Leetcode style challenge to applicant to "assess technical skills". This list is a set of companies who are taking the extra effort to give engineers a dignified application experience and this disqualifies them from being apart of this set.
