### PR TITLE
More consistent ordering of companies that start with numeric values

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ Also check out [No Whiteboards](https://nowhiteboards.io) to search for jobs at 
 
 ---
 
-## 0 - 9
-- [4Degrees](https://4degrees.ai/about/) | Chicago, Illinois | Collaborative pair-programming exercise done through video chat that's representative of the responsibilities of the job then a take-home programming task.
-
 ## A - C
 - [Ableton](https://www.ableton.com/en/about) | Berlin, Germany | Take-home programming task (discussed via Skype), then pair programming and debugging session on-site
 - [Abstract](https://angel.co/abstract/jobs) | San Francisco, CA
@@ -751,6 +748,7 @@ Also check out [No Whiteboards](https://nowhiteboards.io) to search for jobs at 
 - [1000mercis group](http://www.1000mercis.com/#!/careers/?lang=en) | Paris, France | Series of interviews, that go over technical background, past experiences and cultural knowledge
 - [18F](https://18f.gsa.gov/join/) | Remote; Washington, DC; New York, NY; Chicago, IL; San Francisco, CA | take-home coding exercise (2-4 hours), technical and values-match interviews over video chat
 - [3D Hubs](https://3dhubs.com/jobs) | Amsterdam, The Netherlands | Take-home code challenge from our product's domain followed by discussion remote/on-site, sometimes do an additional on-site pair programming session.
+- [4Degrees](https://4degrees.ai/about/) | Chicago, Illinois | Collaborative pair-programming exercise done through video chat that's representative of the responsibilities of the job then a take-home programming task.
 - [500friends](http://500friends.com/who-we-are/careers) | San Francisco, CA; Remote | Take home challenge followed by onsite expansion of the submission and high level discussions (design exercise or overview of past projects)
 - [500Tech](https://500Tech.com) | Tel Aviv, Israel | Pair programming on a laptop in working env
 - [8th Light](https://8thlight.com) | Chicago, IL; London, UK; Los Angeles, CA; New York, NY | Take home code challenge, discussion, pair programming session


### PR DESCRIPTION
I'm not sure if this was on purpose but it seems that 4degrees is out of place, feel free to reject if I am out of line.

<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Add/Update/Remove <CompanyName>

- [X] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [X] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [X] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [ ] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
