### PR TITLE
Removes Ableton

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Also check out [No Whiteboards](https://nowhiteboards.io) to search for jobs at 
 - [4Degrees](https://4degrees.ai/about/) | Chicago, Illinois | Collaborative pair-programming exercise done through video chat that's representative of the responsibilities of the job then a take-home programming task.
 
 ## A - C
-- [Ableton](https://www.ableton.com/en/about) | Berlin, Germany | Take-home programming task (discussed via Skype), then pair programming and debugging session on-site
 - [Abstract](https://angel.co/abstract/jobs) | San Francisco, CA
 - [Accenture](https://www.accenture.com/us-en/careers) | San Francisco, CA / Los Angeles, CA / New York, NY | Technical phone discussion with architecture manager, followed by behavioral interview focusing on soft skills
 - [Accredible](https://www.accredible.com/careers) | Cambridge, UK / San Francisco, CA / Remote | Take home project, then a pair-programming and discussion onsite / Skype round.


### PR DESCRIPTION
Removing ableton from the list as a close friend of mine recently had an interview for an iOS position and during the call it was required for him to perform some classic whiteboard challenges trying to produce ascii art. They call it a pair programming session. There was no take home challenge and the discussion was not about some real life problem that their facing in Ableton (unless they are generating ascii art on iOS all day long for their products?????). 

If there is any doubt I can provide the whiteboard challenge files that they send during the interview on request.

Thanks

PS. My friend would like to remain anonymous 
<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Add/Update/Remove <CompanyName>

- [X] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [X] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [X] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [X] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
