### PR TITLE
Fix Truora website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Also check out [No Whiteboards](https://nowhiteboards.io) to search for jobs at 
 - [Trivago](https://www.trivago.com) | Düsseldorf, Germany | Case Study, Skype Interview, On site Interview with some code review exercises
 - [Trōv](https://boards.greenhouse.io/trov) | Remote | Take-home project with followup interview from actual prospective teammates
 - [Truefit](https://truefit.io/about/) | Pittsburgh, PA | Phone screen, Take-home project, In-person interview with the team that you would join
-- [Truora](https://www.truora.com/en) | Bogotá, Colombia; Cali, Colombia; Remote | Take-home project, followed by phone interview with tech leads to discuss the project.
+- [Truora](https://www.truora.com) | Bogotá, Colombia; Cali, Colombia; Remote | Take-home project, followed by phone interview with tech leads to discuss the project.
 - [Truss](https://truss.works/jobs) | San Francisco, CA; Remote | Phone screen/ Take-home project that resembles a problem Truss has seen many times before / Followup interview about the project / Closing Interview, all interviews done remotely
 - [TuneIn](https://www.tunein.com) | San Fransisco, CA | High level screening over the phone or on-site, take home project, code review and discussion
 - [Twistlock](https://www.twistlock.com) | Tel Aviv, Israel | Takehome

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Also check out [No Whiteboards](https://nowhiteboards.io) to search for jobs at 
 - [Trivago](https://www.trivago.com) | Düsseldorf, Germany | Case Study, Skype Interview, On site Interview with some code review exercises
 - [Trōv](https://boards.greenhouse.io/trov) | Remote | Take-home project with followup interview from actual prospective teammates
 - [Truefit](https://truefit.io/about/) | Pittsburgh, PA | Phone screen, Take-home project, In-person interview with the team that you would join
-- [Truora](https://truora.com) | Bogotá, Colombia; Cali, Colombia; Remote | Take-home project, followed by phone interview with tech leads to discuss the project.
+- [Truora](https://www.truora.com/en) | Bogotá, Colombia; Cali, Colombia; Remote | Take-home project, followed by phone interview with tech leads to discuss the project.
 - [Truss](https://truss.works/jobs) | San Francisco, CA; Remote | Phone screen/ Take-home project that resembles a problem Truss has seen many times before / Followup interview about the project / Closing Interview, all interviews done remotely
 - [TuneIn](https://www.tunein.com) | San Fransisco, CA | High level screening over the phone or on-site, take home project, code review and discussion
 - [Twistlock](https://www.twistlock.com) | Tel Aviv, Israel | Takehome


### PR DESCRIPTION
<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Update Truora

- [x] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [ ] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

## Context
The URL for Truora's website was broken. This PR updates the URL.
