### PR TITLE
Move "pay the candidate for their time" to the top in RECOMMENDATIONS.md

### DIFF
--- a/RECOMMENDATIONS.md
+++ b/RECOMMENDATIONS.md
@@ -4,10 +4,10 @@ Have a suggestion? Please contribute to this doc!
 
 - Instead of using questions that bear no resemblance to the role, adapt the question so that it does. A screening question can be easily adapted so that it applies a "real world" requirement
 - Take-home exercises can be good. Please try to:
+  - pay the candidate for their time
   - time-box them (e.g. under 4 hours)
   - only allow use of the standard library
   - keep it work-related. If their work will primarily be modifying an existing codebase, give them existing code to modify. If it will primarily involve creating new services from scratch, have them build something from scratch.
-  - pay the candidate for their time
 - Give the candidate options:
   - Some candidates might not have the time necessary to complete a take-home exercise. In those scenarios, allow the candidate to take their laptop in to perform a shorter exercise (e.g. pair program on a small issue)
   - Some candidates prefer the whiteboard when discussing a problem, let them


### PR DESCRIPTION
I think paying candidates for the time required to complete take home interviews up to 4 hours in length is a requirement for assigning take home interviews in an ethical manner. Not everyone can afford to work for free for X hours per interview. Given the imbalance of power in an interview setting, asking people to work for 2 to 4 hours for free just does not seem fair.

Additionally, many of the take home interview recommendations are "soft" and somewhat ambiguous. Is a take-home interview 4 hours? are the questions related to the job itself? the interviewer and interviewee may disagree on these points.

however, it is completely umbiguous whether or not candidates are being paid for the time they spend on take-home interviews. companies are either doing it or not. it's harder to handwave away.

This PR moves "pay the candidate for their time" to the top of the take-home interview suggestions list in recommendations.md 



<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Add/Update/Remove <CompanyName>

- [x] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [x] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
