### PR TITLE
Remove DHH tweet from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ The companies and teams listed here use interview techniques and questions that 
 - Discussing a real world problem (with or without whiteboard) is 👍
 - Solving CS trivia, technical puzzles, riddles, brainteasers (with or without whiteboard) is 👎
 
-<a href="https://twitter.com/dhh/status/834146806594433025?lang=en"><img src="https://i.imgur.com/xJV6cF4.png" width="500" /></a>
-
 Please open a [PR](https://github.com/poteto/hiring-without-whiteboards/pull/new/master) to be added.
 
 ### Duds


### PR DESCRIPTION

DHH has become [a controversial figure in recent years over management decisions](https://www.theverge.com/2021/4/27/22406673/basecamp-political-speech-policy-controversy), and as such may turn people off to the work being done in this repo (it does for me, at least!). 

I think the project would be just as, or more, effective without the reference tweet!  


<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Add/Update/Remove <CompanyName>

- [x] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x] ~~I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines~~ (guidelines do not describe how to suggest changes to the project README itself, rather than adding/removing companies)
- [x] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
