### PR TITLE
Remove Instacart

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,6 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [Inmar](https://www.inmar.com/careers) | Winston-Salem, NC; Austin, TX & Remote | Take-home project and conversation-style interviews
 - [Innoplexus](https://jobs.innoplexus.com) | Pune, India; Frankfurt, Germany | Take-home projects and On-site pair programming assignment.
 - [Innovia CoLabs](https://www.innoviacolabs.com) | Rochester, NY / Remote | Zoom interview with two to three engineers and you share projects/code you're proud of; only reviewing code you wrote yourself. Most of the interview is about culture fit and who you are as a person. There is a blog on the website that outlines the interview and will contact you prior to tell you exactly what the interview will be like.
-- [Instacart](https://careers.instacart.com) | San Francisco, CA | Take-home real world project, pair programming on-site
 - [InstantPost](https://internshala.com/internships/internship-at-InstantPost) | Bangaluru, India | Remote assignment followed by Technical and Team round interview
 - [Integral.](https://www.integral.io) | Detroit, MI | Initial remote technical screen featuring test-driven development & pair programming, then on-site full day interview that involves pair programming on production code using test-driven development.
 - [Intelipost](https://www.intelipost.com.br) | São Paulo, BR | Take-home project, on-site code review and presentation (skype available if needed), discussion involving real world problems and interviews with different teams


### PR DESCRIPTION
I applied to Instacart through this list, but won't be going forward with their process. The recruiter, documents that recruiter sent, and further research on Blind, Glassdoor, etc. indicate that they do tech screens through a 3rd party (karat), so you don't even talk to an engineer at the company. Apparently in that screen CS knowledge/topic questions are asked and you're expected to get through 2 leetcode-esque questions in 30 or so minutes. None of this "resembles day-to-day work" to me. 

I don't think that this process fits the spirit of this list at all, but at the very least there's a mismatch in the real process and what's describes here.