### PR TITLE
Removed Amino Payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [Almabase](https://www.almabase.com/careers#believe) | Bengaluru, India | Take-home assignment, design discussion based on take home, low level and high level design rounds based on real life problems, culture fit etc. during onsite.
 - [AlphaSights](https://engineering.alphasights.com) | London, UK / New York, NY / Remote | Initial interview, pair programming then final round with general technical questions
 - [AMAGI](https://amagi.io) | Makati, Philippines | 1) Review of your resume, portfolio, and/or GitHub profile; 2) 1 hour discussion (in-person or Skype) about your goals, experience, personal culture, and how to apply technical solutions to real problems;
-- [Amino Payments](https://angel.co/company/amino-payments/jobs/) | Philadelphia, PA | Real-world technical design and problem discussion, pair programming on-site
 - [Analytical Flavor Systems](https://gastrograph.com) | Manhattan, New York | Code sample or take-home project, both with discussion.
 - [Angaza](https://www.angaza.com/careers/) | San Francisco, CA | Take-home assignment with guaranteed feedback, on-site interviews involving actual day-to-day work
 - [Animech](https://careers.animech.com) | Uppsala, Sweden | Multiple interviews with technical staff with real problem discussions.


### PR DESCRIPTION
Amino Payments was acquired by Integral Ad Science. See here: https://integralads.com/news/ias-acquires-amino-payments/

<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Remove Amino Payments

- [X] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [X] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [X] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [ ] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
