### PR TITLE
Remove Okta

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [aTech Media](https://atech.media) | London, UK | Face to face interview, review of existing open source contributions or, if none are available, asked to write a library for something that interests them
 - [Atlan](https://atlan.com) | New Delhi, India | A mini project (to be done within 8 days), followed by a discussion with the team you're applying to. Then as the final step, a call with one of the founders.
 - [Aura Frames](https://auraframes.com/jobs?gh_src=2ef5cfa32) | New York, NY / San Francisco, CA | Simplified real-world coding task on Coderpad.io, followed by a few hours onsite writing code in our actual codebase.
-- [Auth0 by Okta](https://auth0.com/blog/how-we-hire-engineers) | Bellevue, WA; San Francisco, CA; Buenos Aires, Argentina; Warsaw, Poland; Toronto, Canada; Remote | Series of interviews, go over technical background and past experiences, take-home project
 - [Auto1](https://www.auto1-group.com/jobs) | Berlin, DE | Series of Skype interviews which covers general technical questions, followed by a take-home assignment
 - [Automattic](https://automattic.com/work-with-us/) | Remote | short take-home code test, then a part-time, paid project.
 - [AutoScout24](https://github.com/AutoScout24/hiring) | Munich, Germany | Skype interview followed by home assignment from our day-to-day business and then on-site interview including lunch with a team


### PR DESCRIPTION
Removed Okta from this, I recently interviewed with Okta and they have a series where I was basically asked to solve Alien dictionary problem on leetcode https://leetcode.com/problems/alien-dictionary/description/

<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Add/Update/Remove <CompanyName>

- [x] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [x] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [x] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

<!--
Please give additional context about the interview process if necessary.
-->
I interviewed with Okta for a position of SWE and it was straight up a leetcode question with difficulty level as hard 
Question Link: https://leetcode.com/problems/alien-dictionary/description/
