### PR TITLE
removes Veterans United for starting screening process with Codility …

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,6 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [Vernacular.ai](https://vernacular.ai) | Bangalore, India | Phone screen, Research Paper Discussion (ML Role), Code review/Open-source code navigation/on-screen Pair programming, and discussion with CTO/CEO.
 - [Verve](https://verve.co/careers) | London, UK | An intentionally short, take home exercise that mirrors real project work and incorporates code review elements
 - [Verve Industrial Protection](https://verveindustrial.com/why-verve/careers) | Madison, WI / Remote | Phone screen, project discussion and tooling experience overview in panel interview with team, practical shared-editor coding problem and relevant architectural challenge in hands-on interview
-- [Veterans United Home Loans](https://www.veteransunited.com/careers/) | Columbia, MO | Phone screen, remote or in person pair-programming exercise, and multiple in person panel interviews with developers and managers.
 - [Vingle](https://careers.vingle.net) | Seoul, Korea | Written interview, takehome project, in-person, conversational code review and interviews with engineers and engineering managers
 - [Vinta Software](https://www.vinta.com.br/careers/) | Recife, Brazil | Culture fit interview, architectural challenge, take home project, and pairing over work sample
 - [virtual7](http://virtual7.de/de/karriere) | Kalrsruhe, Germany | Phone interview and on-site interview based on personal experience.


### PR DESCRIPTION
## Remove Veterans United Home Loans

Recent applicant to this job add:
https://veteransunited.wd1.myworkdayjobs.com/VUHL/job/Columbia-MO/Software-Engineer_R4222?source=Linkedin&li_fat_id=710a8e66-5462-4a84-a704-1c9584960613

First screening was a very HackerRank/LeetCode style quiz from Codility. Being vague, but one question involved a faulty find min function, and the other was finding minimum number of ints that add up to K in an array N. 

Appears there was also a "Predictive Index" screening, but it used my results from a different job application 2 years ago. 

No phone interview beforehand, and not a paired programming exercise as previously listed. 


- [X ] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [X ] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [X ] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [X ] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary