### PR TITLE
Remove 18f (permanently closed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,6 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 
 ## Y - \#
 
-- [18F](https://18f.gsa.gov/join/) | Remote; Washington, DC; New York, NY; Chicago, IL; San Francisco, CA | take-home coding exercise (2-4 hours), technical and values-match interviews over video chat
 - [21st Real Estate](https://21re.de) | Berlin, Germany | Phone call for quick personal introduction followed by Video call interview. Finally, a pair-programming session on-site.
 - [23 Technologies](https://23technologies.cloud) | Remote | Three video calls: general introduction, team introduction, contract
 - [3BoxLabs](https://3boxlabs.com) | Remote | Intro call, resume walk-through, and finally live work exercise with ~2 hours independent work followed by ~1.5 hour debrief discussing the work with the rest of the team.


### PR DESCRIPTION
<!--
Thank you for contributing!

Pull requests that do not adhere to the format will be rejected. Please ensure
you complete the following checkboxes.

Please also:

- Add one company at a time.
- Insert in alphabetical order
- Do not sort other listings
-->

## Remove 18f

- [X] I have read the [contributing guidelines](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md)
- [X] I agree to the [Code of Conduct](https://github.com/poteto/hiring-without-whiteboards/blob/master/CODE_OF_CONDUCT.md)
- [X] I have followed the [format](https://github.com/poteto/hiring-without-whiteboards/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [X] (OPTIONAL) In your pull request message, add additional context on the interview process if necessary

18f was [permanently closed](https://www.reuters.com/world/us/musks-doge-fires-federal-tech-team-that-built-free-tax-filing-site-2025-03-01/) by the current U.S. Administration. The link in this list returns NS_ERROR_UNKNOWN_HOST in Firefox. They will certainly not be hiring anytime soon.