### PR TITLE
Add Linear to companies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,8 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [Lightning Jar](https://lightningjar.agency) | San Antonio, Tx | Remote pairing session, Initial interview,discussion on-site
 - [Lightricks](https://www.lightricks.com) | Jerusalem, Israel | Initial interview, Take home project, discussion on-site
 - [LinkAja](https://www.linkaja.id) | Jakarta, Indonesia | Quick introductory chat, followed by take home project for 7 days
-- [LinkResearchTools](https://jobs.linkresearchtools.com/job-offers) | Vienna, Austria | Skype interview, mini take-home exercise, discussion on-site / personal interview
+- [LinkResearchTools](https://jobs.linkresearchtools.com/job-offers) | Vienna, Austria | Skype interview, mini take-
+- - [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment followed by a technical discussion and team interviewshome exercise, discussion on-site / personal interview
 - [Linx Systems](https://www.linxsystems.com) | Bloomington, IL / Remote | 5-10 minute take home project; followed by a non-technical interview; finish up with a second take home project or paired with a developer for a 30-60 minute session.
 - [lise GmbH](https://www.lise.de/karriere/stellenboerse) | Cologne, Germany | Phone interview, followed by getting to know each other in person, a short presentation about any topic you are interested in, pair programming on a real world problem
 - [Listen Lively](https://www.listenlively.com/about#careers) | Remote | 1 hour pair programming exercise on codesandbox; a second 1 hour pair programming exercise on codesandbox; followed by non-technical interview(s) with team members.

--- a/README.md
+++ b/README.md
@@ -493,8 +493,8 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [Lightning Jar](https://lightningjar.agency) | San Antonio, Tx | Remote pairing session, Initial interview,discussion on-site
 - [Lightricks](https://www.lightricks.com) | Jerusalem, Israel | Initial interview, Take home project, discussion on-site
 - [LinkAja](https://www.linkaja.id) | Jakarta, Indonesia | Quick introductory chat, followed by take home project for 7 days
-- [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment followed by a technical discussion and team interviewshome exercise, discussion on-site / personal interview - [LinkResearchTools](https://jobs.linkresearchtools.com/job-offers) | Vienna, Austria | Skype interview, mini take-
-- - [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment followed by a technical discussion and team interviewshome exercise, discussion on-site / personal interview
+- [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment and technical discussion - [LinkResearchTools](https://jobs.linkresearchtools.com/job-offers) | Vienna, Austria | Skype interview, mini take-
+- - [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment and technical discussion
 - [Linx Systems](https://www.linxsystems.com) | Bloomington, IL / Remote | 5-10 minute take home project; followed by a non-technical interview; finish up with a second take home project or paired with a developer for a 30-60 minute session.
 - [lise GmbH](https://www.lise.de/karriere/stellenboerse) | Cologne, Germany | Phone interview, followed by getting to know each other in person, a short presentation about any topic you are interested in, pair programming on a real world problem
 - [Listen Lively](https://www.listenlively.com/about#careers) | Remote | 1 hour pair programming exercise on codesandbox; a second 1 hour pair programming exercise on codesandbox; followed by non-technical interview(s) with team members.

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Also check out [No Whiteboards](https://www.nowhiteboard.org) to search for jobs
 - [Lightning Jar](https://lightningjar.agency) | San Antonio, Tx | Remote pairing session, Initial interview,discussion on-site
 - [Lightricks](https://www.lightricks.com) | Jerusalem, Israel | Initial interview, Take home project, discussion on-site
 - [LinkAja](https://www.linkaja.id) | Jakarta, Indonesia | Quick introductory chat, followed by take home project for 7 days
-- [LinkResearchTools](https://jobs.linkresearchtools.com/job-offers) | Vienna, Austria | Skype interview, mini take-
+- [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment followed by a technical discussion and team interviewshome exercise, discussion on-site / personal interview - [LinkResearchTools](https://jobs.linkresearchtools.com/job-offers) | Vienna, Austria | Skype interview, mini take-
 - - [Linear](https://linear.app/careers) | San Francisco, CA; Remote | Practical take-home assignment followed by a technical discussion and team interviewshome exercise, discussion on-site / personal interview
 - [Linx Systems](https://www.linxsystems.com) | Bloomington, IL / Remote | 5-10 minute take home project; followed by a non-technical interview; finish up with a second take home project or paired with a developer for a 30-60 minute session.
 - [lise GmbH](https://www.lise.de/karriere/stellenboerse) | Cologne, Germany | Phone interview, followed by getting to know each other in person, a short presentation about any topic you are interested in, pair programming on a real world problem


### PR DESCRIPTION
Adds [Linear](https://linear.app/careers) to the companies list in alphabetical order.

Linear uses a practical take-home assignment and technical discussion rather than whiteboard/leetcode interviews.